### PR TITLE
Reduce batch size to fit T5 paper

### DIFF
--- a/bigscience/gins/enc_dec_c4_prefix_lm.gin
+++ b/bigscience/gins/enc_dec_c4_prefix_lm.gin
@@ -21,8 +21,8 @@ TASK_FEATURE_LENGTHS = {
 }
 
 # ----- This should be reduced by two because we have fancy packing
-train/utils.DatasetConfig.batch_size = 1024
-train_eval/utils.DatasetConfig.batch_size = 1024
+train/utils.DatasetConfig.batch_size = 64 # BATCH_SIZE / 2
+train_eval/utils.DatasetConfig.batch_size = 64 # BATCH_SIZE /2
 
 models.EncoderDecoderModel.feature_converter_cls = @seqio.PassThroughFeatureConverter
 

--- a/bigscience/gins/trainer_base.gin
+++ b/bigscience/gins/trainer_base.gin
@@ -8,17 +8,17 @@ from t5x import utils
 import task
 
 MIXTURE_OR_TASK_MODULE = "t5.data.mixtures"
-TRAIN_STEPS = 32768
+TRAIN_STEPS = 524288
 DROPOUT_RATE = 0.0
 
 train/utils.DatasetConfig:
-  batch_size = 2048
+  batch_size = 128
   use_cached = True
   pack = True
   use_custom_packing_ops = False
 
 train_eval/utils.DatasetConfig:
-  batch_size = 2048
+  batch_size = 128
   use_cached = True
   pack = True
   use_custom_packing_ops = False
@@ -29,7 +29,7 @@ train_script.train:
   eval_steps = 100
   random_seed = None
 
-trainer.Trainer.num_microbatches = 8 # 2048 // 8
+# trainer.Trainer.num_microbatches = 8 # 2048 // 8
 utils.create_learning_rate_scheduler.warmup_steps = 10000
 
 utils.SaveCheckpointConfig:

--- a/bigscience/gins/trainer_base.gin
+++ b/bigscience/gins/trainer_base.gin
@@ -24,16 +24,16 @@ train_eval/utils.DatasetConfig:
   use_custom_packing_ops = False
 
 train_script.train:
-  eval_period = 1000
-  stats_period = 200
-  eval_steps = 100
+  eval_period = 15000
+  stats_period = 3000
+  eval_steps = 1500
   random_seed = None
 
 # trainer.Trainer.num_microbatches = 8 # 2048 // 8
 utils.create_learning_rate_scheduler.warmup_steps = 10000
 
 utils.SaveCheckpointConfig:
-  period = 2000  # checkpoint frequency
+  period = 30000  # checkpoint frequency
   keep = None # only keep one checkpoint
 
 partitioning.ModelBasedPjitPartitioner:


### PR DESCRIPTION
One of the things we want to understand is why does out model seem to underperform?

One thing we noticed is that learning rate/learning rate schedule is extracted from the t5 paper, but we've update the batch size to fit with Meg-DS (ie 2048 instead of 128)?

Typically learning rate is constant for the first 1e4 steps, however since t5 starts decaying at 128 * 1e4 * 512 = 655M tokens whereas we start decaying at 2048 * 1e4 * 512 = 10B tokens (which is about 1/3 of the entire training data). Can this explain the poor performances? If so, what do we so? Reduce batch size to 128? Tune the learning_rate_scheduler.warmup_steps to be 1e4 / (2048 / 128) = 6250 . I'd be in favor of reducing batch size to mimick T5 paper.

In this PR I suggest reducing the batch size back to the original paper.

